### PR TITLE
Add information about where validation errors occurred to the errors.

### DIFF
--- a/ext/serializer.cpp
+++ b/ext/serializer.cpp
@@ -454,6 +454,11 @@ void ThriftSerializer::writeStruct(VALUE klass, VALUE data) {
   FieldBegin fieldBegin;
   FieldInfo *fieldInfo;
   auto fields = FindOrCreateFieldInfoMap(klass);
+
+  if (!validateStruct(klass, data, false, false)) {
+    return;
+  }
+
   for (auto const & entry : *fields) {
     fieldBegin.fid = entry.first;
     fieldInfo = entry.second;

--- a/ext/serializer.cpp
+++ b/ext/serializer.cpp
@@ -136,7 +136,11 @@ static inline VALUE make_ruby_binary(const string &val) {
   return rb_str_new(val.c_str(), val.size());
 }
 
-static void raise_exc_with_struct_and_field_names(VALUE exc_class, VALUE msg, VALUE outer_struct_class, VALUE field_sym) {
+static void raise_exc_with_struct_and_field_names(
+        VALUE exc_class,
+        VALUE msg,
+        VALUE outer_struct_class,
+        VALUE field_sym) {
   VALUE struct_name = rb_class_name(outer_struct_class);
   VALUE field_name = rb_sym_to_s(field_sym);
   VALUE args[3] = {msg, struct_name, field_name};
@@ -514,7 +518,12 @@ static void raise_type_mismatch(VALUE outer_struct, VALUE field_sym) {
       field_sym);
 }
 
-bool validateArray(FieldInfo *type, VALUE arr, bool recursive, VALUE outer_struct, VALUE field_sym) {
+bool validateArray(
+        FieldInfo *type,
+        VALUE arr,
+        bool recursive,
+        VALUE outer_struct,
+        VALUE field_sym) {
   long length = RARRAY_LEN(arr);
   for (long i = 0; i < length; i++) {
     if (!validateAny(type, rb_ary_entry(arr, i), recursive, outer_struct, field_sym)) {
@@ -623,7 +632,8 @@ bool validateStruct(VALUE klass, VALUE data, bool validateContainerTypes,
       }
       continue;
     }
-    if (validateContainerTypes && !validateAny(entry.second, val, recursive, data, entry.second->symName)) {
+    if (validateContainerTypes &&
+        !validateAny(entry.second, val, recursive, data, entry.second->symName)) {
       return false;
     }
   }

--- a/ext/serializer.h
+++ b/ext/serializer.h
@@ -92,7 +92,7 @@ private:
 
 bool validateStruct(VALUE klass, VALUE data, bool validateContainerTypes,
                     bool recursive);
-bool validateAny(FieldInfo *type, VALUE val, bool recursive);
+bool validateAny(FieldInfo *type, VALUE val, bool recursive, VALUE outer_struct, VALUE field_sym);
 FieldInfoMap *FindOrCreateFieldInfoMap(VALUE klass);
 FieldInfo *CreateFieldInfo(VALUE field_map_entry);
 FieldInfoMap *CreateFieldInfoMap(VALUE klass);

--- a/lib/sparsam/base_class.rb
+++ b/lib/sparsam/base_class.rb
@@ -73,7 +73,6 @@ module Sparsam
     end
 
     def serialize(prot = Sparsam::CompactProtocol)
-      validate
       s = Sparsam::Serializer.new(prot, "")
       s.serialize(self.class, self)
     end

--- a/lib/sparsam/exceptions.rb
+++ b/lib/sparsam/exceptions.rb
@@ -8,14 +8,22 @@ module Sparsam
   end
 
   class MissingMandatory < Exception
-    def initialize(msg)
-      super
+    attr_reader :struct_name, :field_name
+
+    def initialize(msg, struct_name = nil, field_name = nil)
+      @struct_name = struct_name
+      @field_name = field_name
+      super(msg)
     end
   end
 
   class TypeMismatch < Exception
-    def initialize(msg)
-      super
+    attr_reader :struct_name, :field_name
+
+    def initialize(msg, struct_name = nil, field_name = nil)
+      @struct_name = struct_name
+      @field_name = field_name
+      super(msg)
     end
   end
 

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -92,6 +92,7 @@ describe 'Sparsam' do
       expect {
         Sparsam.validate(NotSS, data, Sparsam::STRICT)
       }.to raise_error(Sparsam::TypeMismatch)
+
       expect {
         Sparsam.validate(EasilyInvalid, data, Sparsam::STRICT)
       }.to raise_error(Sparsam::TypeMismatch)
@@ -149,6 +150,21 @@ describe 'Sparsam' do
       expect {
         Sparsam.validate(EasilyInvalid, data, Sparsam::STRICT)
       }.to raise_error(Sparsam::TypeMismatch)
+    end
+
+    it "includes additional data in TypeMismatch errors" do
+      data = EasilyInvalid.new
+      data.id_i32 = "definitely a string"
+
+      e = nil
+      begin
+        Sparsam.validate(EasilyInvalid, data, Sparsam::STRICT)
+      rescue Sparsam::TypeMismatch => exception
+        e = exception
+      end
+
+      e.struct_name.should == EasilyInvalid.name
+      e.field_name.should == "id_i32"
     end
 
     it "works with crazy thriftness" do

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -205,6 +205,20 @@ describe 'Sparsam' do
       expect { data.validate }.to raise_error(Sparsam::MissingMandatory)
     end
 
+    it "includes additional information on missing required fields in exception" do
+      data = MiniRequired.new
+
+      e = nil
+      begin
+        data.validate
+      rescue Sparsam::MissingMandatory => exception
+        e = exception
+      end
+
+      e.struct_name.should == MiniRequired.name
+      e.field_name.should == "id_i32"
+    end
+
     it "will throw errors when given junk data" do
       expect {
         Sparsam::Deserializer.deserialize(SS, "wolololololol")


### PR DESCRIPTION
This adds the name of the struct and of the field where the validation error occurred to the type mismatch or missing mandatory errors.  This allows the user to know where the problem occurred.

Additionally, this adds basic, required fields validation as part of `writeStruct` to prevent the issue of nested structs that lack required fields being serialized with no complaints.  This brings the behavior back in line with the standard thrift gem.

These changes are done in a backwards compatible way (minus changing the behavior of serializing invalid structs a bit).

/cc @andyfangdz 