### PR TITLE
Combine strict validation with serialization

### DIFF
--- a/ext/ruby_hooks.c
+++ b/ext/ruby_hooks.c
@@ -69,7 +69,6 @@ void Init_sparsam_native() {
   Sparsam = rb_define_module("Sparsam");
   rb_define_singleton_method(Sparsam, "init!", sparsam_init_bang, 0);
   rb_define_singleton_method(Sparsam, "cache_fields", cache_fields, 1);
-  rb_define_singleton_method(Sparsam, "validate", serializer_validate, 3);
   VALUE SparsamSerializer = rb_define_class_under(Sparsam, "Serializer", rb_cObject);
   SparsamNativeError =
       rb_define_class_under(Sparsam, "Exception", rb_eStandardError);

--- a/ext/serializer.h
+++ b/ext/serializer.h
@@ -85,14 +85,11 @@ public:
 private:
   VALUE readUnion(VALUE klass);
   VALUE readAny(TType ttype, FieldInfo *field_info);
-  void writeAny(TType ttype, FieldInfo *field_info, VALUE data);
+  void writeAny(TType ttype, FieldInfo *field_info, VALUE data, VALUE outer_struct, VALUE field_sym);
   void skip_n_type(uint32_t n, TType ttype);
   void skip_n_pair(uint32_t n, TType type_a, TType type_b);
 };
 
-bool validateStruct(VALUE klass, VALUE data, bool validateContainerTypes,
-                    bool recursive);
-bool validateAny(FieldInfo *type, VALUE val, bool recursive, VALUE outer_struct, VALUE field_sym);
 FieldInfoMap *FindOrCreateFieldInfoMap(VALUE klass);
 FieldInfo *CreateFieldInfo(VALUE field_map_entry);
 FieldInfoMap *CreateFieldInfoMap(VALUE klass);

--- a/lib/sparsam.rb
+++ b/lib/sparsam.rb
@@ -8,3 +8,11 @@ require 'sparsam/union'
 require 'sparsam/deserializer'
 
 Sparsam.init!
+
+module Sparsam
+  # Deprecated
+  def self.validate(klass, data, strictness)
+    data.serialize
+    true
+  end
+end

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -361,7 +361,6 @@ describe 'Sparsam' do
         struct: US.new(id_i32: 10),
         union: UN.new(id_s: "woo"),
         complex: Complex(1),
-        bigint: 2**128,
         rational: Rational(2, 3),
       }
 
@@ -398,10 +397,46 @@ describe 'Sparsam' do
             )
           end
 
-          begin
+          expect {
             s.serialize
-          rescue TypeError, RangeError, NoMethodError, Sparsam::TypeMismatch
-          end
+          }.to(
+            raise_error(Sparsam::TypeMismatch),
+            "assigning #{field} : #{type} a value of " \
+            "#{val.inspect} : #{val_type} did not raise TypeMismatch"
+          )
+        end
+      end
+    end
+
+    it "handles integer ranges" do
+      fields = {
+        a_byte: 8,
+        an_i16: 16,
+        an_i32: 32,
+        an_i64: 64,
+      }
+
+      fields.each do |field, size|
+        s = EveryType.new
+
+        max_val = 2**(size-1)-1
+
+        [max_val, ~max_val].each do |val|
+          s.send(:"#{field}=", val)
+
+          expect {
+            s.serialize
+          }.to_not raise_error, "#{field} of #{size} bits unable to hold #{val}"
+        end
+
+        [max_val + 1, ~(max_val + 1)].each do |val|
+          s.send(:"#{field}=", val)
+          expect {
+            s.serialize
+          }.to(
+            raise_error(RangeError),
+            "#{field} of #{size} bits apparently able to hold value #{val} in defiance of nature"
+          )
         end
       end
     end

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -408,35 +408,37 @@ describe 'Sparsam' do
       end
     end
 
-    it "handles integer ranges" do
-      fields = {
-        a_byte: 8,
-        an_i16: 16,
-        an_i32: 32,
-        an_i64: 64,
-      }
+    unless RUBY_VERSION =~ /^1\.9/
+      it "handles integer ranges" do
+        fields = {
+          a_byte: 8,
+          an_i16: 16,
+          an_i32: 32,
+          an_i64: 64,
+        }
 
-      fields.each do |field, size|
-        s = EveryType.new
+        fields.each do |field, size|
+          s = EveryType.new
 
-        max_val = 2**(size-1)-1
+          max_val = 2**(size - 1) - 1
 
-        [max_val, ~max_val].each do |val|
-          s.send(:"#{field}=", val)
+          [max_val, ~max_val].each do |val|
+            s.send(:"#{field}=", val)
 
-          expect {
-            s.serialize
-          }.to_not raise_error, "#{field} of #{size} bits unable to hold #{val}"
-        end
+            expect {
+              s.serialize
+            }.not_to raise_error, "#{field} of #{size} bits unable to hold #{val}"
+          end
 
-        [max_val + 1, ~(max_val + 1)].each do |val|
-          s.send(:"#{field}=", val)
-          expect {
-            s.serialize
-          }.to(
-            raise_error(RangeError),
-            "#{field} of #{size} bits apparently able to hold value #{val} in defiance of nature"
-          )
+          [max_val + 1, ~(max_val + 1)].each do |val|
+            s.send(:"#{field}=", val)
+            expect {
+              s.serialize
+            }.to(
+              raise_error(RangeError),
+              "#{field} of #{size} bits apparently able to hold value #{val} in defiance of nature"
+            )
+          end
         end
       end
     end


### PR DESCRIPTION
Prior to this change, validation and serialization were separate,
mostly overlapping operations, but with divergence at the edges.
Validating a struct threw one kind of error, while serializing an
invalid struct would usually fail, but with a different kind of error.
Validation also did not enforce integer range restrictions, while
serialization, as a side effect of Ruby library methods, did (to some
degree, the range checks for the smaller types may not be entirely
accurate).

This change removes the separate validation (shimming Sparsam.validate
to just attempt serialization).  Serialization now throws TypeMismatch
errors (but with revamped error messages).

/cc @andyfangdz 

