### PR TITLE
Remove field question mark methods

### DIFF
--- a/lib/sparsam/base_class.rb
+++ b/lib/sparsam/base_class.rb
@@ -23,20 +23,7 @@ module Sparsam
     def self.generate_accessors(klass)
       klass::FIELDS.each do |field_key, field_info|
         field_accessor(klass, field_key, field_info)
-        qmark_isset_method(klass, field_info)
       end
-    end
-
-    # TODO(Ben Hughes): Do we ever use those, these are an unexpected
-    # definition of predicate accessors
-    def self.qmark_isset_method(klass, field_info)
-      field_name = field_info[:name]
-
-      klass.class_eval(<<-EOF, __FILE__, __LINE__)
-        def #{field_name}?
-          !#{field_name}.nil?
-        end
-      EOF
     end
 
     def self.generate_default_values(klass)


### PR DESCRIPTION
These methods like `struct.foo?` answer whether a field has been set.
We don't know whether a field has actually been set, so it just checks
whether the field is nil.  This doesn't seem super useful, and the use
of the question mark is confusing, since in idiomatic ruby, this
predicate form would be a nice way to see whether a boolean field was
true or false.

This required minimal changes in internal validation.

/cc @AngerM 