### PR TITLE
Handle eigenclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.1
+* Fix crash when serialize is called with a mismatched type
+
 # 0.2.0
 * Move validation into serialization
 * Remove field question mark methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.2
+* Handle eigenclasses correctly in serializer
+
 # 0.2.1
 * Fix crash when serialize is called with a mismatched type
 

--- a/ext/serializer.cpp
+++ b/ext/serializer.cpp
@@ -518,7 +518,7 @@ void ThriftSerializer::writeAny(TType ttype, FieldInfo *field_info,
   }
 
   case protocol::T_SET: {
-    if (CLASS_OF(actual) != SetClass) {
+    if (rb_class_real(CLASS_OF(actual)) != SetClass) {
       raise_type_mismatch(outer_struct, field_sym);
     }
 
@@ -553,7 +553,7 @@ void ThriftSerializer::writeAny(TType ttype, FieldInfo *field_info,
   }
 
   case protocol::T_STRUCT: {
-    if (CLASS_OF(actual) != field_info->klass) {
+    if (rb_class_real(CLASS_OF(actual)) != field_info->klass) {
       raise_type_mismatch(outer_struct, field_sym);
     }
 
@@ -616,7 +616,7 @@ void ThriftSerializer::writeStruct(VALUE klass, VALUE data) {
 VALUE serializer_writeStruct(VALUE self, VALUE klass, VALUE data) {
   watch_for_texcept() get_ts();
 
-  if (CLASS_OF(data) != klass) {
+  if (rb_class_real(CLASS_OF(data)) != klass) {
     VALUE expected_name = rb_class_name(klass);
     VALUE actual_name = rb_class_name(CLASS_OF(data));
 

--- a/sparsam.gemspec
+++ b/sparsam.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'sparsam'
-  s.version     = '0.2.1'
+  s.version     = '0.2.2'
   s.authors     = ['Airbnb Thrift Developers']
   s.email       = ['foundation.performance-eng@airbnb.com']
   s.homepage    = 'http://thrift.apache.org'

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -442,5 +442,23 @@ describe 'Sparsam' do
         end
       end
     end
+
+    it 'handles structs with modified eigenclasses' do
+      nested_struct = US.new
+
+      class << nested_struct
+        def foo
+        end
+      end
+
+      data = SS.new(us_i: nested_struct)
+
+      class << data
+        def foo
+        end
+      end
+
+      expect { data.serialize }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
The serializer previously used exact class equality for type checks on
structs.  This breaks down in cases where a struct instance exists with
a modified eigenclass (since CLASS_OF(struct) will return the eigenclass
rather than real class).  It would be fairly weird to open up a thrift
struct's eigenclass (please don't do this), but apparently pry does
this, leading to all sorts of confusion.  The fix is to use
rb_class_real.

/cc @AngerM 