### PR TITLE
Bring back the namespaced option

### DIFF
--- a/compiler/src/main.cc
+++ b/compiler/src/main.cc
@@ -1043,6 +1043,7 @@ int main(int argc, char** argv) {
   int i;
   std::string out_path;
   bool out_path_is_absolute = false;
+  bool namespaced_option = false;
 
   // Setup time string
   time_t now = time(NULL);
@@ -1104,6 +1105,7 @@ int main(int argc, char** argv) {
         g_incl_searchpath.push_back(arg);
       } else if (strcmp(arg, "-namespaced") == 0) {
         generator_strings.push_back("ruby:namespaced");
+        namespaced_option = true;
       } else if ((strcmp(arg, "-o") == 0) || (strcmp(arg, "-out") == 0)) {
         out_path_is_absolute = (strcmp(arg, "-out") == 0) ? true : false;
         arg = argv[++i];
@@ -1252,7 +1254,9 @@ int main(int argc, char** argv) {
     // Reset yylineno for the heck of it.  Use 1 instead of 0 because
     // That is what shows up during argument parsing.
     yylineno = 1;
-    generator_strings.push_back("ruby");
+    if (!namespaced_option) {
+      generator_strings.push_back("ruby");
+    }
     // Generate it!
     generate(program, generator_strings);
     delete program;

--- a/compiler/src/main.cc
+++ b/compiler/src/main.cc
@@ -1102,6 +1102,13 @@ int main(int argc, char** argv) {
           usage();
         }
         g_incl_searchpath.push_back(arg);
+      } else if (strcmp(arg, "-gen") == 0) {
+        arg = argv[++i];
+        if (arg == NULL) {
+          fprintf(stderr, "Missing generator specification\n");
+          usage();
+        }
+        generator_strings.push_back(arg);
       } else if ((strcmp(arg, "-o") == 0) || (strcmp(arg, "-out") == 0)) {
         out_path_is_absolute = (strcmp(arg, "-out") == 0) ? true : false;
         arg = argv[++i];

--- a/compiler/src/main.cc
+++ b/compiler/src/main.cc
@@ -1102,13 +1102,8 @@ int main(int argc, char** argv) {
           usage();
         }
         g_incl_searchpath.push_back(arg);
-      } else if (strcmp(arg, "-gen") == 0) {
-        arg = argv[++i];
-        if (arg == NULL) {
-          fprintf(stderr, "Missing generator specification\n");
-          usage();
-        }
-        generator_strings.push_back(arg);
+      } else if (strcmp(arg, "-namespaced") == 0) {
+        generator_strings.push_back("ruby:namespaced");
       } else if ((strcmp(arg, "-o") == 0) || (strcmp(arg, "-out") == 0)) {
         out_path_is_absolute = (strcmp(arg, "-out") == 0) ? true : false;
         arg = argv[++i];

--- a/compiler/version.h.in
+++ b/compiler/version.h.in
@@ -1,1 +1,1 @@
-#define THRIFT_VERSION "0.1.0"
+#define THRIFT_VERSION "0.1.1"

--- a/docs/1-usage.md
+++ b/docs/1-usage.md
@@ -7,6 +7,11 @@ except that `--gen` switch is not supported (since we are only generating files 
 ./sparsam-gen -o <out-dir> <schema.thrift>
 ```
 
+If you want ruby files generated in idiomatic directories, you can run:
+```
+./sparsam-gen -namespaced -o <out-dir> <schema.thrift>
+```
+
 ## Serialization & Deserialization {#serialization}
 
 ```ruby


### PR DESCRIPTION
### About
`namespaced` is a useful feature to generate Ruby files in idiomatic namespaced directories. I believe it was removed unintentionally when removing the `--gen` option.

```
./sparsam-gen -help
Available generators (and options):
  ruby (Ruby Sparsam bindings):
    namespaced:      Generate files in idiomatic namespaced directories.
```

This PR bring back the `--gen`, while not enforcing it.

### Test
Test that both following command work. The later one is able to generate files in idiomatic namespaced directories.
```
./sparsam-gen test.thrift
```
```
./sparsam-gen --gen ruby:namespaced test.thrift
```

### Next step
Update doc accordingly

@AngerM 