### PR TITLE
Relax version requirement on rubocop on ruby >1.9

### DIFF
--- a/sparsam.gemspec
+++ b/sparsam.gemspec
@@ -30,6 +30,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '< 11.0'
 
   # specify versions with 1.9 support
-  s.add_development_dependency 'rubocop', '0.41.2'
-  s.add_development_dependency 'rubocop-rspec', '1.5.0'
+  if RUBY_VERSION =~ /^1\.9/
+    s.add_development_dependency 'rubocop', '0.41.2'
+    s.add_development_dependency 'rubocop-rspec', '1.5.0'
+  else
+    s.add_development_dependency 'rubocop'
+    s.add_development_dependency 'rubocop-rspec'
+  end
 end


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418

/cc @AngerM 