### PR TITLE
Update to Thrift 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 before_install:
   - sudo apt-get update
   - sudo apt-get install automake bison flex g++ git libboost1.55-all-dev libevent-dev libssl-dev libtool make pkg-config -y
-  - wget http://mirror.reverse.net/pub/apache/thrift/0.10.0/thrift-0.10.0.tar.gz -O /tmp/thrift.tar.gz
+  - wget http://mirror.reverse.net/pub/apache/thrift/0.11.0/thrift-0.11.0.tar.gz -O /tmp/thrift.tar.gz
   - bash ./travis-build-thrift.sh
   - gem install bundler --no-document
 

--- a/ext/serializer.cpp
+++ b/ext/serializer.cpp
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <thrift/protocol/TBinaryProtocol.h>
 #include <thrift/protocol/TCompactProtocol.h>
-#include <boost/make_shared.hpp>
+#include <thrift/stdcxx.h>
 #include <vector>
 
 using namespace std;
@@ -89,7 +89,7 @@ void initialize_runtime_constants() {
 
 void serializer_init(void *serializer, int protocol, void *str_arg1,
                      uint32_t len) {
-  using ::boost::shared_ptr;
+  using ::apache::thrift::stdcxx::shared_ptr;
   using ::apache::thrift::protocol::TProtocol;
   using ::apache::thrift::protocol::TBinaryProtocol;
   using ::apache::thrift::protocol::TCompactProtocol;
@@ -97,13 +97,13 @@ void serializer_init(void *serializer, int protocol, void *str_arg1,
   ThriftSerializer *ts = (ThriftSerializer *)(serializer);
   shared_ptr<TMemoryBuffer> strBuffer;
   if (str_arg1 != NULL) {
-    strBuffer = boost::make_shared<TMemoryBuffer>(
+    strBuffer = stdcxx::make_shared<TMemoryBuffer>(
       (uint8_t *)str_arg1,
       len,
       TMemoryBuffer::TAKE_OWNERSHIP
     );
   } else {
-    strBuffer = boost::make_shared<TMemoryBuffer>();
+    strBuffer = stdcxx::make_shared<TMemoryBuffer>();
   }
   Proto proto = static_cast<Proto>(protocol);
   if (proto == compact) {

--- a/ext/serializer.h
+++ b/ext/serializer.h
@@ -39,7 +39,7 @@ void initialize_runtime_constants();
 #ifdef __cplusplus
 } // end extern "C"
 
-#include <boost/shared_ptr.hpp>
+#include <thrift/stdcxx.h>
 #include <map>
 #include <string>
 #include <thrift/protocol/TProtocol.h>
@@ -76,8 +76,8 @@ typedef spp::sparse_hash_map<VALUE, FieldInfoMap *> KlassFieldsCache;
 class ThriftSerializer {
 public:
   ThriftSerializer(){};
-  boost::shared_ptr< ::apache::thrift::protocol::TProtocol > tprot;
-  boost::shared_ptr< ::apache::thrift::transport::TMemoryBuffer > tmb;
+  apache::thrift::stdcxx::shared_ptr< ::apache::thrift::protocol::TProtocol > tprot;
+  apache::thrift::stdcxx::shared_ptr< ::apache::thrift::transport::TMemoryBuffer > tmb;
 
   VALUE readStruct(VALUE klass);
   void writeStruct(VALUE klass, VALUE data);

--- a/travis-build-thrift.sh
+++ b/travis-build-thrift.sh
@@ -1,6 +1,6 @@
 cd /tmp 
 tar xvf thrift.tar.gz 
-cd thrift-0.10.0 
+cd thrift-0.11.0
 cmake . -DBUILD_COMPILER=OFF -DBUILD_C_GLIB=OFF -DBUILD_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_JAVA=OFF 
 make -j && sudo make install
 sudo ldconfig


### PR DESCRIPTION
- Updates namespace for memory operations - (see [THRIFT-2221](https://issues.apache.org/jira/browse/THRIFT-2221))