### PR TITLE
Switch to a non-sudo travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,13 @@ cache:
     - $HOME/thrift
 
 env:
-  - CC="ccache gcc"
-  - CXX="ccache g++"
-  - THRIFT_SHA256SUM="2289d02de6e8db04cbbabb921aeb62bfe3098c4c83f36eec6c31194301efa10b  thrift-0.10.0.tar.gz"
-  - THRIFT_URL="http://mirror.reverse.net/pub/apache/thrift/0.10.0/thrift-0.10.0.tar.gz"
-  - THRIFT_FILE="thrift-0.10.0.tar.gz"
-  - THRIFT_DIR="thrift-0.10.0"
+  global:
+    - CC="ccache gcc"
+    - CXX="ccache g++"
+    - THRIFT_SHA256SUM="2289d02de6e8db04cbbabb921aeb62bfe3098c4c83f36eec6c31194301efa10b  thrift-0.10.0.tar.gz"
+    - THRIFT_URL="http://mirror.reverse.net/pub/apache/thrift/0.10.0/thrift-0.10.0.tar.gz"
+    - THRIFT_FILE="thrift-0.10.0.tar.gz"
+    - THRIFT_DIR="thrift-0.10.0"
 
 before_install:
   # don't do this in prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
 language: ruby
-sudo: enabled
+sudo: false
 dist: trusty
+
+cache:
+  ccache: true
+  directories:
+    - $HOME/thrift
+
+env:
+  - CC="ccache gcc"
+  - CXX="ccache g++"
+  - THRIFT_SHA256SUM="2289d02de6e8db04cbbabb921aeb62bfe3098c4c83f36eec6c31194301efa10b  thrift-0.10.0.tar.gz"
+  - THRIFT_URL="http://mirror.reverse.net/pub/apache/thrift/0.10.0/thrift-0.10.0.tar.gz"
+  - THRIFT_FILE="thrift-0.10.0.tar.gz"
+  - THRIFT_DIR="thrift-0.10.0"
+
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install automake bison flex g++ git libboost1.55-all-dev libevent-dev libssl-dev libtool make pkg-config -y
-  - wget http://mirror.reverse.net/pub/apache/thrift/0.10.0/thrift-0.10.0.tar.gz -O /tmp/thrift.tar.gz
+  # don't do this in prod
   - bash ./travis-build-thrift.sh
-  - gem install bundler --no-document
+  - export LIBRARY_PATH="$HOME/thrift/$THRIFT_DIR/lib:$LIBRARY_PATH"
+  - export LD_LIBRARY_PATH="$HOME/thrift/$THRIFT_DIR/lib:$LD_LIBRARY_PATH"
+  - export CPATH="$HOME/thrift/$THRIFT_DIR/lib/cpp/src:$HOME/thrift/$THRIFT_DIR:$CPATH"
 
 rvm:
   - 1.9.3
@@ -14,7 +28,23 @@ rvm:
   - 2.2.1
   - 2.3.0
   - 2.4.0
+
 script:
   # Please add to Rakefile instead of this section.
   - bundle exec rake
   - bundle exec rubocop
+
+addons:
+  apt:
+    packages:
+      - automake
+      - bison 
+      - flex 
+      - g++ 
+      - git 
+      - libboost1.55-all-dev 
+      - libevent-dev 
+      - libssl-dev 
+      - libtool 
+      - make 
+      - pkg-config

--- a/travis-build-thrift.sh
+++ b/travis-build-thrift.sh
@@ -1,6 +1,17 @@
-cd /tmp 
-tar xvf thrift.tar.gz 
-cd thrift-0.10.0 
-cmake . -DBUILD_COMPILER=OFF -DBUILD_C_GLIB=OFF -DBUILD_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_JAVA=OFF 
-make -j && sudo make install
-sudo ldconfig
+#!/usr/bin/env bash
+set -euxo pipefail
+
+mkdir -p $HOME/thrift
+cd $HOME/thrift
+
+echo "$THRIFT_SHA256SUM" > SHA256SUMS
+ret=0
+sha256sum -c SHA256SUMS 2>&1 || ret=$?
+
+if [ $ret -ne 0 ]; then
+    wget -N "$THRIFT_URL"
+    tar xvf "$THRIFT_FILE"
+    cd "$THRIFT_DIR"
+    cmake . -DBUILD_COMPILER=OFF -DBUILD_C_GLIB=OFF -DBUILD_PYTHON=OFF -DBUILD_TESTING=OFF -DBUILD_JAVA=OFF
+    make -j
+fi


### PR DESCRIPTION
This change enables travis to pick up the build immediately, without any delay (`sudo: enabled` has significant queueing time these days). Additionally, it removes the time it takes to build thrift in each build.

**Before**: queueing: ~20 minutes, building: ~3 minutes
**After**: queueing: *0 minutes (!)*, building: ~2 minutes 
