### PR TITLE
Include additional information in serializing/deserializing w/ type mismatches.

### DIFF
--- a/ext/serializer.cpp
+++ b/ext/serializer.cpp
@@ -167,8 +167,8 @@ static void raise_type_mismatch(VALUE outer_struct, VALUE field_sym,
 
 static void raise_type_mismatch(VALUE outer_struct, VALUE field_sym, int ttype,
                                 VALUE actual) {
-  raise_type_mismatch(outer_struct, field_sym,
-                      TTypeNames[(size_t)ttype].c_str(), actual);
+  raise_type_mismatch(outer_struct, field_sym, TTypeName((size_t)ttype).c_str(),
+                      actual);
 }
 
 static void raise_type_mismatch(VALUE outer_struct, VALUE field_sym,
@@ -359,8 +359,8 @@ VALUE ThriftSerializer::readStruct(VALUE klass) {
       raise_exc_with_struct_and_field_names(
           SparsamTypeMismatchError,
           rb_sprintf("Mismatched type (definition: %s, found: %s)",
-                     TTypeNames[fieldBegin.ftype].c_str(),
-                     TTypeNames[typeId].c_str()),
+                     TTypeName(fieldBegin.ftype).c_str(),
+                     TTypeName(typeId).c_str()),
           klass, fieldInfo->symName);
     }
 

--- a/ext/serializer.cpp
+++ b/ext/serializer.cpp
@@ -358,8 +358,9 @@ VALUE ThriftSerializer::readStruct(VALUE klass) {
     if (typeId != fieldBegin.ftype) {
       raise_exc_with_struct_and_field_names(
           SparsamTypeMismatchError,
-          rb_sprintf("Mismatched type (definition: %d, found: %d)",
-                     fieldBegin.ftype, typeId),
+          rb_sprintf("Mismatched type (definition: %s, found: %s)",
+                     TTypeNames[fieldBegin.ftype].c_str(),
+                     TTypeNames[typeId].c_str()),
           klass, fieldInfo->symName);
     }
 

--- a/ext/serializer.cpp
+++ b/ext/serializer.cpp
@@ -154,22 +154,41 @@ static void raise_exc_with_struct_and_field_names(VALUE exc_class,
   rb_exc_raise(e);
 }
 
-static void raise_type_mismatch(VALUE outer_struct, VALUE field_sym) {
-  raise_exc_with_struct_and_field_names(SparsamTypeMismatchError,
-                                        rb_str_new2("Mismatched type"),
+static void raise_type_mismatch(VALUE outer_struct, VALUE field_sym,
+                                const char *expected, VALUE actual) {
+  VALUE actual_name = rb_class_name(CLASS_OF(actual));
+  VALUE msg = rb_sprintf(
+      "Mismatched type (expected to be compatible with: %s, found: %s)",
+      expected, RSTRING_PTR(actual_name));
+
+  raise_exc_with_struct_and_field_names(SparsamTypeMismatchError, msg,
                                         CLASS_OF(outer_struct), field_sym);
 }
 
+static void raise_type_mismatch(VALUE outer_struct, VALUE field_sym, int ttype,
+                                VALUE actual) {
+  raise_type_mismatch(outer_struct, field_sym,
+                      TTypeNames[(size_t)ttype].c_str(), actual);
+}
+
+static void raise_type_mismatch(VALUE outer_struct, VALUE field_sym,
+                                VALUE klass, VALUE actual) {
+  VALUE expected_name = rb_class_name(klass);
+  raise_type_mismatch(outer_struct, field_sym, RSTRING_PTR(expected_name),
+                      actual);
+}
+
 static inline long raise_type_mismatch_as_value(VALUE outer_struct,
-                                                VALUE field_sym) {
-  raise_type_mismatch(outer_struct, field_sym);
+                                                VALUE field_sym, int ttype,
+                                                VALUE actual) {
+  raise_type_mismatch(outer_struct, field_sym, ttype, actual);
   return 0;
 }
 
 static inline void Sparsam_Check_Type(VALUE x, int t, VALUE outer_struct,
                                       VALUE field_sym) {
   if (!(RB_TYPE_P(x, t))) {
-    raise_type_mismatch(outer_struct, field_sym);
+    raise_type_mismatch(outer_struct, field_sym, t, x);
   }
 }
 
@@ -419,19 +438,21 @@ static inline long raise_bignum_range_error_as_value() {
   return 0;
 }
 
-#define CONVERT_FIXNUM(CONVERT)                     \
-  ((FIXNUM_P(actual))                               \
-       ? CONVERT(actual)                            \
-       : ((RB_TYPE_P(actual, T_BIGNUM))             \
-              ? raise_bignum_range_error_as_value() \
-              : raise_type_mismatch_as_value(outer_struct, field_sym)))
+#define CONVERT_FIXNUM(CONVERT, INTENDED)                             \
+  ((FIXNUM_P(actual))                                                 \
+       ? CONVERT(actual)                                              \
+       : ((RB_TYPE_P(actual, T_BIGNUM))                               \
+              ? raise_bignum_range_error_as_value()                   \
+              : raise_type_mismatch_as_value(outer_struct, field_sym, \
+                                             INTENDED, actual)))
 
-#define CONVERT_I64                     \
-  ((FIXNUM_P(actual))                   \
-       ? (LONG_LONG)FIX2LONG(actual)    \
-       : ((RB_TYPE_P(actual, T_BIGNUM)) \
-              ? rb_big2ll(actual)       \
-              : raise_type_mismatch_as_value(outer_struct, field_sym)))
+#define CONVERT_I64                                                   \
+  ((FIXNUM_P(actual))                                                 \
+       ? (LONG_LONG)FIX2LONG(actual)                                  \
+       : ((RB_TYPE_P(actual, T_BIGNUM))                               \
+              ? rb_big2ll(actual)                                     \
+              : raise_type_mismatch_as_value(outer_struct, field_sym, \
+                                             protocol::T_I64, actual)))
 
 #ifdef RB_FLOAT_TYPE_P
 #define FLOAT_TYPE_P(x) RB_FLOAT_TYPE_P(x)
@@ -439,10 +460,11 @@ static inline long raise_bignum_range_error_as_value() {
 #define FLOAT_TYPE_P(x) RB_TYPE_P(x, T_FLOAT)
 #endif
 
-#define CONVERT_FLOAT(CONVERT) \
-  ((FLOAT_TYPE_P(actual))      \
-       ? CONVERT(actual)       \
-       : raise_type_mismatch_as_value(outer_struct, field_sym))
+#define CONVERT_FLOAT(CONVERT)                                 \
+  ((FLOAT_TYPE_P(actual))                                      \
+       ? CONVERT(actual)                                       \
+       : raise_type_mismatch_as_value(outer_struct, field_sym, \
+                                      protocol::T_DOUBLE, actual))
 
 static inline bool convertBool(VALUE actual, VALUE outer_struct,
                                VALUE field_sym) {
@@ -452,7 +474,7 @@ static inline bool convertBool(VALUE actual, VALUE outer_struct,
     case Qfalse:
       return false;
     default:
-      raise_type_mismatch(outer_struct, field_sym);
+      raise_type_mismatch(outer_struct, field_sym, protocol::T_BOOL, actual);
   }
 
   /* unreachable */
@@ -482,12 +504,12 @@ void ThriftSerializer::writeAny(TType ttype, FieldInfo *field_info,
                                 VALUE actual, VALUE outer_struct,
                                 VALUE field_sym) {
   switch (ttype) {
-    HANDLE_TYPE(I16, I16, CONVERT_FIXNUM(SHORT_CONVERT))
-    HANDLE_TYPE(I32, I32, CONVERT_FIXNUM(FIX2INT))
+    HANDLE_TYPE(I16, I16, CONVERT_FIXNUM(SHORT_CONVERT, protocol::T_I16))
+    HANDLE_TYPE(I32, I32, CONVERT_FIXNUM(FIX2INT, protocol::T_I32))
     HANDLE_TYPE(I64, I64, CONVERT_I64)
     HANDLE_TYPE(BOOL, Bool, convertBool(actual, outer_struct, field_sym))
     HANDLE_TYPE(DOUBLE, Double, CONVERT_FLOAT(NUM2DBL))
-    HANDLE_TYPE(BYTE, Byte, CONVERT_FIXNUM(byte_convert))
+    HANDLE_TYPE(BYTE, Byte, CONVERT_FIXNUM(byte_convert, protocol::T_BYTE))
 
     case protocol::T_STRING: {
       Sparsam_Check_Type(actual, T_STRING, outer_struct, field_sym);
@@ -517,7 +539,7 @@ void ThriftSerializer::writeAny(TType ttype, FieldInfo *field_info,
 
     case protocol::T_SET: {
       if (rb_class_real(CLASS_OF(actual)) != SetClass) {
-        raise_type_mismatch(outer_struct, field_sym);
+        raise_type_mismatch(outer_struct, field_sym, protocol::T_SET, actual);
       }
 
       VALUE ary = rb_funcall(actual, intern_for_to_a, 0);
@@ -555,7 +577,7 @@ void ThriftSerializer::writeAny(TType ttype, FieldInfo *field_info,
 
     case protocol::T_STRUCT: {
       if (rb_class_real(CLASS_OF(actual)) != field_info->klass) {
-        raise_type_mismatch(outer_struct, field_sym);
+        raise_type_mismatch(outer_struct, field_sym, field_info->klass, actual);
       }
 
       static const string cname = "";

--- a/ext/serializer.h
+++ b/ext/serializer.h
@@ -48,6 +48,17 @@ void initialize_runtime_constants();
 
 using ::apache::thrift::protocol::TType;
 
+// transposed from:
+// https://github.com/apache/thrift/blob/0.10.0/lib/cpp/src/thrift/protocol/TProtocol.h#L176
+// with: https://gist.github.com/andyfangdz/d4d52daa9f8a75223e76e92657036bb0
+// fun fact: it's not sorted there
+std::string TTypeNames[] = {
+    "T_STOP",   "T_VOID",    "T_BOOL", "T_BYTE or T_I08",
+    "T_DOUBLE", "T_UNKNOWN", "T_I16",  "T_UNKNOWN",
+    "T_I32",    "T_U64",     "T_I64",  "T_STRING or T_UTF7",
+    "T_STRUCT", "T_MAP",     "T_SET",  "T_LIST",
+    "T_UTF8",   "T_UTF16"};
+
 typedef uint16_t FieldIdIndex;
 typedef uint16_t KlassIndex;
 
@@ -75,8 +86,10 @@ typedef spp::sparse_hash_map<VALUE, FieldInfoMap*> KlassFieldsCache;
 class ThriftSerializer {
  public:
   ThriftSerializer(){};
+  // clang-format off
   boost::shared_ptr< ::apache::thrift::protocol::TProtocol > tprot;
   boost::shared_ptr< ::apache::thrift::transport::TMemoryBuffer > tmb;
+  // clang-format on
 
   VALUE readStruct(VALUE klass);
   VALUE readUnion(VALUE klass);

--- a/ext/serializer.h
+++ b/ext/serializer.h
@@ -52,12 +52,19 @@ using ::apache::thrift::protocol::TType;
 // https://github.com/apache/thrift/blob/0.10.0/lib/cpp/src/thrift/protocol/TProtocol.h#L176
 // with: https://gist.github.com/andyfangdz/d4d52daa9f8a75223e76e92657036bb0
 // fun fact: it's not sorted there
-std::string TTypeNames[] = {
+const std::string TTypeNames[] = {
     "T_STOP",   "T_VOID",    "T_BOOL", "T_BYTE or T_I08",
     "T_DOUBLE", "T_UNKNOWN", "T_I16",  "T_UNKNOWN",
     "T_I32",    "T_U64",     "T_I64",  "T_STRING or T_UTF7",
     "T_STRUCT", "T_MAP",     "T_SET",  "T_LIST",
     "T_UTF8",   "T_UTF16"};
+
+const size_t TTypeMaxID = sizeof(TTypeNames) / sizeof(TTypeNames[0]);
+
+const std::string TTypeUnknown = "T_UNKNOWN";
+
+#define TTypeName(typeId) \
+  (typeId < TTypeMaxID ? TTypeNames[typeId] : TTypeUnknown)
 
 typedef uint16_t FieldIdIndex;
 typedef uint16_t KlassIndex;

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -238,7 +238,7 @@ describe 'Sparsam' do
         e = exception
       end
       e.message.should include("T_I32", "String")
-      
+
       data = EveryType.new
       data.a_struct = EveryType.new
 

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -227,6 +227,30 @@ describe 'Sparsam' do
       e.field_name.should == "id_i32"
     end
 
+    it "includes additional information on serializing mismatched types" do
+      data = MiniRequired.new
+      data.id_i32 = "not an i32"
+
+      e = nil
+      begin
+        data.serialize
+      rescue Sparsam::TypeMismatch => exception
+        e = exception
+      end
+      e.message.should include("T_I32", "String")
+      
+      data = EveryType.new
+      data.a_struct = EveryType.new
+
+      e = nil
+      begin
+        data.serialize
+      rescue Sparsam::TypeMismatch => exception
+        e = exception
+      end
+      e.message.should include("US", "EveryType")
+    end
+
     it "will throw errors when given junk data" do
       expect {
         Sparsam::Deserializer.deserialize(SS, "wolololololol")

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -251,6 +251,20 @@ describe 'Sparsam' do
       e.message.should include("US", "EveryType")
     end
 
+    it "includes additional information on deserializing mismatched types" do
+      data = NotSS.new
+      data.id_s = "not an i32"
+
+      serialized = data.serialize
+
+      begin
+        Sparsam::Deserializer.deserialize(SS, serialized)
+      rescue Sparsam::TypeMismatch => exception
+        e = exception
+      end
+      e.message.should include("T_I32", "T_STRING")
+    end
+
     it "will throw errors when given junk data" do
       expect {
         Sparsam::Deserializer.deserialize(SS, "wolololololol")


### PR DESCRIPTION
Previously, when we encounter a *field* in a struct that has a mismatched type, we either output a simple `Mismatched type` with no mention of the actual type found and the type expected, or only include Thrift's `TType` IDs. Both of these are non-ideal.

In this change, we enable developers to see the type of the object that's actually passed to Sparsam, as well as the name of Thrift types it's expected to be compatible with. 

**tl;dr**: Type mismatch errors will now look like:

```
Mismatched type (expected to be compatible with: T_BYTE or T_I08, found: String)
```

Instead of just:

```
Mismatched type
```