### PR TITLE
Annotations on generated class

### DIFF
--- a/compiler/src/generate/t_ruby_generator.cc
+++ b/compiler/src/generate/t_ruby_generator.cc
@@ -811,10 +811,12 @@ void t_ruby_generator::generate_field_annotations(t_ruby_ofstream& out, t_struct
 
     out.indent() << "'" << (*f_iter)->get_name() << "' => {" << endl;
 
+    out.indent_up()
     map<string, string>::const_iterator it;
     for (it=ann.begin(); it!=ann.end(); ++it) {
-      out.indent() << "  '" << it->first << "' => '" << it->second << "'," << endl;
+      out.indent() << "'" << it->first << "' => '" << it->second << "'," << endl;
     }
+    out.indent_down()
 
     out.indent() << "}," << endl;
   }

--- a/compiler/src/generate/t_ruby_generator.cc
+++ b/compiler/src/generate/t_ruby_generator.cc
@@ -809,14 +809,14 @@ void t_ruby_generator::generate_field_annotations(t_ruby_ofstream& out, t_struct
     int key = (*f_iter)->get_key();
     string name = (*f_iter)->get_name();
 
-    out.indent() << "'" << (*f_iter)->get_name() << "' => {" << endl;
+    out.indent() << "" << (*f_iter)->get_key() << " => {" << endl;
 
-    out.indent_up()
+    out.indent_up();
     map<string, string>::const_iterator it;
     for (it=ann.begin(); it!=ann.end(); ++it) {
       out.indent() << "'" << it->first << "' => '" << it->second << "'," << endl;
     }
-    out.indent_down()
+    out.indent_down();
 
     out.indent() << "}," << endl;
   }

--- a/compiler/src/generate/t_ruby_generator.cc
+++ b/compiler/src/generate/t_ruby_generator.cc
@@ -88,7 +88,7 @@ class t_ruby_generator : public t_oop_generator {
         const std::string& field_name,
         t_const_value* field_value,
         bool optional,
-        std::map<string, string> annotations);
+        std::map<string, string>* annotations);
     void generate_writer(t_ruby_ofstream& out, t_struct* tstruct);
     void generate_reader(t_ruby_ofstream& out, t_struct* tstruct);
     void generate_serialize_map_element(t_ruby_ofstream& out, t_map* tmap);
@@ -781,12 +781,11 @@ void t_ruby_generator::generate_writer(t_ruby_ofstream& out, t_struct* tstruct) 
 }
 
 void t_ruby_generator::generate_schema_annotations(t_ruby_ofstream& out, t_struct* tstruct) {
-  std::map<string, string> ann = tstruct->annotations_;
   std::map<string, string>::const_iterator it;
 
   out.indent() << "ANNOTATIONS = {" << endl;
   out.indent_up();
-  for (it = ann.begin(); it != ann.end(); ++it) {
+  for (it = tstruct->annotations_.begin(); it != tstruct->annotations_.end(); ++it) {
     out.indent() << "'" << it->first << "' => '" << it->second << "'," << endl;
   }
   out.indent_down();
@@ -814,7 +813,7 @@ void t_ruby_generator::generate_field_defns(t_ruby_ofstream& out, t_struct* tstr
                         (*f_iter)->get_name(),
                         (*f_iter)->get_value(),
                         (*f_iter)->get_req() == t_field::T_OPTIONAL,
-                        (*f_iter)->annotations_);
+                        &(*f_iter)->annotations_);
   }
   out.indent_down();
   out << endl;
@@ -827,7 +826,7 @@ void t_ruby_generator::generate_field_data(
     const std::string& field_name = "",
     t_const_value* field_value = NULL,
     bool optional = false,
-    std::map<string, string> annotations = std::map<string, string>()) {
+    std::map<string, string>* annotations = NULL) {
   field_type = get_true_type(field_type);
 
   // Begin this field's defn
@@ -883,12 +882,12 @@ void t_ruby_generator::generate_field_data(
     out.indent() << "," << endl;
   }
 
-  if (annotations.size() > 0) {
+  if (annotations != NULL) {
     out.indent() << ":annotations => {" << endl;
     out.indent_up();
 
     map<string, string>::const_iterator it;
-    for (it=annotations.begin(); it!=annotations.end(); ++it) {
+    for (it = annotations->begin(); it != annotations->end(); ++it) {
       out.indent() << "'" << it->first << "' => '" << it->second << "'," << endl;
     }
 


### PR DESCRIPTION
### Description

I would like to pass through the `field` and `schema` annotations to the generated ruby class.  My specific use case is to provide field level hints for added semantic validation.  For example:

```thrift
struct MySchema {
  1: optional string some_id ( regex = '[0-9]+-[0-9]+', length_lt = '20' )
} (
  some = "meta data",
  other = "data"
)
```

Which would then generate a class like

```ruby
class MySchema < ::Sparsam::Struct
  FIELDS = { 
    1 => {
      :type => ::Sparsam::Types::STRING,
      :name => 'some_id',
      :optional => true,
      :annotations => {
        'length_lt' => '20',
        'regex' => '[0-9]+-[0-9]+',
      },  
    }   
  }

  ANNOTATIONS = { 
    'other' => 'data',
    'some' => 'meta data',
  }

  init_thrift_struct(self)
end
```

And then my client code can utilize the annotations to provide extra checks.  I imagine there could be a lot of other good use cases of passing these through as well.

There is an added cost to the build size, my current build went from `37mb` to `38mb` so less than 3%.  But obviously the more annotations, the more the impact.