### PR TITLE
Actually return true on struct equality

### DIFF
--- a/lib/sparsam/struct.rb
+++ b/lib/sparsam/struct.rb
@@ -16,6 +16,8 @@ module Sparsam
         reader = name_to_accessors(info[:name]).reader
         return false unless send(reader) == other.send(reader)
       end
+
+      true
     end
     alias_method :eql?, :==
   end


### PR DESCRIPTION
In some cases, `struct == other_struct` will return the result of `each_field` which is a hash. While this is truthy, it's not `true`. This one-liner fixes this problem.