### PR TITLE
Override Sparsam::Struct#hash method

### DIFF
--- a/lib/sparsam/struct.rb
+++ b/lib/sparsam/struct.rb
@@ -18,5 +18,9 @@ module Sparsam
       end
     end
     alias_method :eql?, :==
+
+    def hash
+      to_h.hash
+    end
   end
 end

--- a/spec/sparsam_spec.rb
+++ b/spec/sparsam_spec.rb
@@ -31,6 +31,12 @@ describe 'Sparsam' do
       subdata.id_s.should == "id_s default"
     end
 
+    it "respects equality of Sets" do
+      us1 = US.new
+      us2 = US.new
+      expect(Set[us1]).to eq(Set[us2])
+    end
+
     it "can serialize structs" do
       data = SS.new
       data.id_i32 = 10


### PR DESCRIPTION
This ensures that different Set objects with Thrift objects having the same value are considered equal.

@pariser