### PR TITLE
More robust extension configuration

### DIFF
--- a/docs/0-install.md
+++ b/docs/0-install.md
@@ -3,12 +3,49 @@
 ## Sparsam Gem Installation
 
 Sparsam depends on Apache Thrift and Boost, so the first step is to install the dependencies:
-- On macOS: `brew install thrift boost`
+- On macOS: `brew install thrift@0.9 boost`
 - On linux: `sudo apt-get install libthrift-dev libboost1.55-all-dev`
 
 Afterwards, the gem for sparsam can be installed normally:
 ```bash
 gem install sparsam
+```
+
+Note that sparsam may not compile with newer versions of thrift. e.g.
+
+```
+serializer.cpp:113:43: error: no matching constructor for initialization of 'apache::thrift::protocol::TCompactProtocol' (aka 'TCompactProtocolT<apache::thrift::transport::TTransport>')
+```
+
+Older versions of thrift (such as version 0.9) are known to work.
+
+## Homebrew Integration
+
+`extconf.rb` will detect and automatically use a `brew` executable on
+`$PATH` to configure the compiler to build against Homebrew's thrift and
+boost packages.
+
+By default, it will automatically look for and use the `thrift@0.9`
+and `boost` packages.
+
+To disable automatic Homebrew integration, pass `--disable-homebrew` to
+the build.
+
+To specify an alternative Homebrew package providing thrift, pass
+`--with-homebrew-thrift-package=<package>`. e.g.
+`--with-homebrew-thrift-package=mythrift`.
+
+To specify an alternative Homebrew package providing boost, pass
+`--with-homebrew-boost-package=<package>`.
+
+The default configuration can be set globally using `bundle config`. e.g.:
+
+```
+# Disable default Homebrew integration.
+$ bundle config --global build.sparsam --disable-homebrew
+
+# To use an alternative Homebrew package providing thrift.
+$ bundle config --global build.sparsam '--with-homebrew-thrift-package=mythrift'
 ```
 
 ## Sparsam Compiler Installation
@@ -26,7 +63,7 @@ sudo apt-get update || sudo apt-get install cmake automake bison flex g++ git li
 
 Requirements for Mac
 ```
-brew install thrift bison boost cmake
+brew install thrift@0.9 bison boost cmake
 ```
 
 Use the following steps to build using cmake:

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -7,12 +7,70 @@ if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   $CPPFLAGS += $CXXFLAGS
 end
 
+brew = find_executable('brew')
+
+# Automatically use homebrew to discover thrift package if it is
+# available and not disabled via --disable-homebrew.
+use_homebrew = enable_config('homebrew', brew)
+
+if use_homebrew
+  $stderr.puts "Using #{brew} to locate thrift and boost packages"
+  $stderr.puts '(disable Homebrew integration via --disable-homebrew)'
+
+  thrift_package = with_config('homebrew-thrift-package', 'thrift@0.9')
+  $stderr.puts "looking for Homebrew thrift package '#{thrift_package}'"
+  $stderr.puts '(change Homebrew thrift package name via --with-homebrew-thrift-package=<package>)'
+
+  thrift_prefix = `#{brew} --prefix #{thrift_package}`.strip
+
+  unless File.exists?(thrift_prefix)
+    $stderr.puts "#{thrift_prefix} does not exist"
+    $stderr.puts "To resolve, `brew install #{thrift_package}` or pass"
+    $stderr.puts '--with-homebrew-thrift-package=<package> to this build to specify'
+    $stderr.puts 'an alternative thrift package to build against. e.g.:'
+    $stderr.puts
+    $stderr.puts '  $ bundle config --global build.sparsam --with-homebrew-thrift-package=mythrift'
+
+    raise "Homebrew package #{thrift_package} not installed"
+  end
+
+  $stderr.puts "using Homebrew thrift at #{thrift_prefix}"
+  $CFLAGS << " -I#{thrift_prefix}/include"
+  $CXXFLAGS << " -I#{thrift_prefix}/include"
+  $CPPFLAGS << " -I#{thrift_prefix}/include"
+  $LDFLAGS << " -L#{thrift_prefix}/lib"
+
+  # Also add boost to the includes search path if it is installed.
+  boost_package = with_config('homebrew-boost-package', 'boost')
+  $stderr.puts "looking for Homebrew boost package '#{boost_package}'"
+  $stderr.puts '(change Homebrew boost package name via --with-homebrew-boost-package=<package>)'
+
+  boost_prefix = `#{brew} --prefix #{boost_package}`.strip
+
+  if File.exists?(boost_prefix)
+    $stderr.puts("using Homebrew boost at #{boost_prefix}")
+    $CFLAGS << " -I#{boost_prefix}/include"
+    $CXXFLAGS << " -I#{boost_prefix}/include"
+    $CPPFLAGS << " -I#{boost_prefix}/include"
+  else
+    $stderr.puts 'Homebrew boost not found; assuming boost is in default search paths'
+  end
+end
+
 have_func("strlcpy", "string.h")
-have_library("thrift")
+
+unless have_library("thrift")
+  raise 'thrift library not found; aborting since compile would fail'
+end
+
 libs = ['-lthrift']
 
 libs.each do |lib|
   $LOCAL_LIBS << "#{lib} "
 end
+
+# Ideally we'd validate boost as well. But boost is header only and
+# mkmf's have_header() doesn't work with C++ headers.
+# https://bugs.ruby-lang.org/issues/4924
 
 create_makefile 'sparsam_native'


### PR DESCRIPTION
Previously, `extconf.rb` was rather simple and blindly trusted that
things would work. This commit drastically changes the situation.

`extconf.rb` now errors hard if `have_library('thrift')` does not
work. This should short-circuit build/compile time errors that would
later occur at build time due to a missing/wrong thrift configuration.

But the bigger change is the introduction of new functionality to
sniff for and automatically use packages provided by Homebrew.

Essentially, if the `brew` executable is found, we call
`brew --prefix thrift@0.9` and `brew --prefix boost` to resolve
and automatically use include and library paths under these paths,
if available.

If the `thrift@0.9` and `boost` Homebrew packages are installed,
the extension configuration should "just work." I've tested this on
both an x86-64 and M1 device using macOS Monterey.

Because not all users may desire the automatic Homebrew usage or
its choice of packages to use, configuration options to disable
the functionality or point at different Homebrew packages have been
added and documented.

`extconf.rb` is also a bit more chattier now to help debug issues.
Failures during Homebrew integration are more actionable to help users
self-diagnose.