### PR TITLE
Release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.9
+
+- Improve extconf.rb to abort if it can't find thrift library
+- Improve extconf.rb support for dependencies installed via homebrew on osx
+
 ## 0.2.8
 
 - Generate `INVERTED_VALUE_MAP` (map from string to int value) constant inside generated enum modules

--- a/sparsam.gemspec
+++ b/sparsam.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'sparsam'
-  s.version     = '0.2.8'
+  s.version     = '0.2.9'
   s.authors     = ['Airbnb Thrift Developers']
   s.email       = ['foundation.performance-eng@airbnb.com']
   s.homepage    = 'http://thrift.apache.org'


### PR DESCRIPTION
Release with extconf.rb improvements thanks to @airbnb-gps !

- Improve extconf.rb to abort if it can't find thrift library
- Improve extconf.rb support for dependencies installed via homebrew on osx