### PR TITLE
Fix broken compile for ruby 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - CC="ccache gcc"
     - CXX="ccache g++"
     - THRIFT_SHA256SUM="2289d02de6e8db04cbbabb921aeb62bfe3098c4c83f36eec6c31194301efa10b  thrift-0.10.0.tar.gz"
-    - THRIFT_URL="http://mirror.reverse.net/pub/apache/thrift/0.10.0/thrift-0.10.0.tar.gz"
+    - THRIFT_URL="http://archive.apache.org/dist/thrift/0.10.0/thrift-0.10.0.tar.gz"
     - THRIFT_FILE="thrift-0.10.0.tar.gz"
     - THRIFT_DIR="thrift-0.10.0"
 
@@ -24,7 +24,6 @@ before_install:
   - export CPATH="$HOME/thrift/$THRIFT_DIR/lib/cpp/src:$HOME/thrift/$THRIFT_DIR:$CPATH"
 
 rvm:
-  - 1.9.3
   - 2.1.8
   - 2.2.1
   - 2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.10
+
+- Remove `Sparsam_Check_Type` and replace it with `SPARSAM_CHECK_TYPE` to fix compilation building with Ruby 3.*
+
 ## 0.2.9
 
 - Improve extconf.rb to abort if it can't find thrift library

--- a/sparsam.gemspec
+++ b/sparsam.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'sparsam'
-  s.version     = '0.2.9'
+  s.version     = '0.2.10'
   s.authors     = ['Airbnb Thrift Developers']
   s.email       = ['foundation.performance-eng@airbnb.com']
   s.homepage    = 'http://thrift.apache.org'


### PR DESCRIPTION
1. Switch `Sparsam_Check_Type` to a macro, which evades the type problems when compiling against ruby 3.* using `RB_TYPE_P` inside a method with an int argument type. Also remove `extern C` which creates problems in 3.*
2. Drop Ruby 1.9 testing. (It is time to let it go)

Travis [appears to be unable to install rvm for ruby 3.0 or 3.1](https://travis-ci.org/github/airbnb/sparsam/jobs/774811638#L908), so I haven't added them here, but testing locally in 3.* succeeded. 