### PR TITLE
Sparsam: Cycle detection for Thrift includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.11
+
+- Port cycle breaking logic for Thrift includes over from Apache Thrift
+
 ## 0.2.10
 
 - Remove `Sparsam_Check_Type` and replace it with `SPARSAM_CHECK_TYPE` to fix compilation building with Ruby 3.*

--- a/compiler/version.h.in
+++ b/compiler/version.h.in
@@ -1,1 +1,1 @@
-#define THRIFT_VERSION "0.1.1"
+#define THRIFT_VERSION "0.1.1.sparsam.0.2.11"

--- a/sparsam.gemspec
+++ b/sparsam.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'sparsam'
-  s.version     = '0.2.10'
+  s.version     = '0.2.11'
   s.authors     = ['Airbnb Thrift Developers']
   s.email       = ['foundation.performance-eng@airbnb.com']
   s.homepage    = 'http://thrift.apache.org'


### PR DESCRIPTION
Ported this over from Apache Thrift. Looks like it was added there sometime after Sparsam forked off.

Testing this manually (since the compiler doesn't have a test suite):
```
// ---- common.thrift

struct CommonStruct {}

// ---- leaf_one.thrift

include "common.thrift"

struct LeafOne {
  1: optional common.CommonStruct commonStruct
}

// ---- leaf_two.thrift

include "common.thrift"
include "leaf_one.thrift"

struct LeafTwo {
  1: optional common.CommonStruct commonStruct
  2: optional leaf_one.LeafOne leafOne
}
```
Results:
```
$ ./compiler/build/sparsam-gen -namespaced -out tmp leaf_two.thrift

Scanning includes from /Users/jeremiah_boyle/repos/sparsam/leaf_two.thrift
Scanning includes from /Users/jeremiah_boyle/repos/sparsam/common.thrift
Parsing types from /Users/jeremiah_boyle/repos/sparsam/common.thrift with parent /Users/jeremiah_boyle/repos/sparsam/leaf_two.thrift
Scanning includes from /Users/jeremiah_boyle/repos/sparsam/leaf_one.thrift
Skipping recursion for parsed program /Users/jeremiah_boyle/repos/sparsam/common.thrift
Parsing types from /Users/jeremiah_boyle/repos/sparsam/common.thrift with parent /Users/jeremiah_boyle/repos/sparsam/leaf_one.thrift
Parsing types from /Users/jeremiah_boyle/repos/sparsam/leaf_one.thrift with parent /Users/jeremiah_boyle/repos/sparsam/leaf_two.thrift
Parsing types from /Users/jeremiah_boyle/repos/sparsam/leaf_two.thrift with parent null
Program to generate code: /Users/jeremiah_boyle/repos/sparsam/leaf_two.thrift
Generating code with arg "ruby:namespaced" for /Users/jeremiah_boyle/repos/sparsam/leaf_two.thrift
```
