### PR TITLE
Add support for Ruby 3.2

### DIFF
--- a/.github/workflows/rspec_rubocop.yml
+++ b/.github/workflows/rspec_rubocop.yml
@@ -36,6 +36,8 @@ jobs:
           bundler-version: latest
         - ruby-version: 3.1
           bundler-version: latest
+        - ruby-version: 3.2
+          bundler-version: latest
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/.github/workflows/rspec_rubocop.yml
+++ b/.github/workflows/rspec_rubocop.yml
@@ -36,8 +36,6 @@ jobs:
           bundler-version: latest
         - ruby-version: 3.1
           bundler-version: latest
-        - ruby-version: 3.2
-          bundler-version: latest
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.12
+
+- Migrate the deprecated `File.exists` to `File.exist` to unblock usage in Ruby 3.2
+
 ## 0.2.11
 
 - Port cycle breaking logic for Thrift includes over from Apache Thrift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.12
 
-- Migrate the deprecated `File.exists` to `File.exist` to unblock usage in Ruby 3.2
+- Migrate the deprecated `File.exists?` to `File.exist?` to unblock usage in Ruby 3.2
 
 ## 0.2.11
 

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -23,7 +23,7 @@ if use_homebrew
 
   thrift_prefix = `#{brew} --prefix #{thrift_package}`.strip
 
-  unless File.exists?(thrift_prefix)
+  unless File.exist?(thrift_prefix)
     warn "#{thrift_prefix} does not exist"
     warn "To resolve, `brew install #{thrift_package}` or pass"
     warn '--with-homebrew-thrift-package=<package> to this build to specify'
@@ -47,7 +47,7 @@ if use_homebrew
 
   boost_prefix = `#{brew} --prefix #{boost_package}`.strip
 
-  if File.exists?(boost_prefix)
+  if File.exist?(boost_prefix)
     warn("using Homebrew boost at #{boost_prefix}")
     $CFLAGS << " -I#{boost_prefix}/include"
     $CXXFLAGS << " -I#{boost_prefix}/include"

--- a/sparsam.gemspec
+++ b/sparsam.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'sparsam'
-  s.version     = '0.2.11'
+  s.version     = '0.2.12'
   s.authors     = ['Airbnb Thrift Developers']
   s.email       = ['foundation.performance-eng@airbnb.com']
   s.homepage    = 'http://thrift.apache.org'


### PR DESCRIPTION
## Current Error
Sparsam currently fails from Ruby 3.2.2 with the following error:

<img width="577" alt="Screenshot 2023-12-14 at 2 06 56 PM" src="https://github.com/airbnb/sparsam/assets/48065/6e114895-1c57-4f6c-87c1-97eb2b9038d1">



## Deprecated method removed
This `File.exists` method has been deprecated since Ruby 2.1 ([link](https://bugs.ruby-lang.org/issues/17391)) and has now been removed in Ruby 3.2:
<img width="723" alt="Screenshot 2023-12-14 at 2 07 34 PM" src="https://github.com/airbnb/sparsam/assets/48065/a04dd91e-f1c2-44f6-aacd-3d1342561687">
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

## Please Review
@santiagorodriguez96 @pariser @iancmyers 